### PR TITLE
Corrected the InsertNums link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ We can use the following command to generate a _random UUID_ in UPPERCASE:
 
 ### Insert Nums ###
 
-_Text Pastry_ has a build in support for the [Insert Nums](https://bitbucket.org/markstahler/insert-nums/) syntax by providing three numbers separated by one space:
+_Text Pastry_ has a build in support for the [Insert Nums](https://github.com/jbrooksuk/InsertNums/) syntax by providing three numbers separated by one space:
 
 	N M P
 


### PR DESCRIPTION
markstahler cloned my original InsertNums into BitBucket. I've changed the link to my version, which should be replacing the Package Control install too.
