### PR TITLE
Support for generating binary values

### DIFF
--- a/config/TextPastryCommands.json
+++ b/config/TextPastryCommands.json
@@ -117,6 +117,12 @@
         {"match": "^(HRANGE|HEX) (0x[\\da-fA-F]+)[-, ](0x[\\da-fA-F]+)$", "command": "text_pastry_hex_range", "args": {"start": "$2", "stop": "$3", "hexFormatFlag": "X"} },
         {"match": "^(HRANGE|HEX) (0x[\\da-fA-F]+)$", "command": "text_pastry_hex_range", "args": {"stop": "$2", "hexFormatFlag": "X"} },
 
+        {"match": "^bin (-?\\d+)[-, ](-?\\d+)[, ](-?\\d+)[, ](\\d+)[, ](.)$", "command": "text_pastry_bin", "args": {"start": "$1", "stop": "$2", "step": "$3", "padding": "$4", "fillchar": "$5"} },
+        {"match": "^bin (-?\\d+)[-, ](-?\\d+)[, ](-?\\d+)[, ](\\d+)$", "command": "text_pastry_bin", "args": {"start": "$1", "stop": "$2", "step": "$3", "padding": "$4"} },
+        {"match": "^bin (-?\\d+)[-, ](-?\\d+)[, ](-?\\d+)$", "command": "text_pastry_bin", "args": {"start": "$1", "stop": "$2", "step": "$3"} },
+        {"match": "^bin (-?\\d+)[-, ](-?\\d+)$", "command": "text_pastry_bin", "args": {"start": "$1", "stop": "$2"} },
+        {"match": "^bin (-?\\d+)$", "command": "text_pastry_bin", "args": {"stop": "$1"} },
+        
         // add x-arg support to date ranges
         {"match": "^(?:days|day) ?((?:\\b).*) x(\\d+)$", "command": "text_pastry_date_range", "args": {"text": "$1", "repeat": "$2"} },
         {"match": "^(?:weeks|week) ?((?:\\b).*) x(\\d+)$", "command": "text_pastry_date_range", "args": {"text": "$1", "step_size": "week", "repeat": "$2"} },


### PR DESCRIPTION
Working with hardware description (mainly VHDL and Verilog languages), several times I need a list of binary values.

So, I duplicated the range command. And in the new duplicate comand, the generated values are converted from integer to binary values.

The atributes from the new command are the same from **range** command, but accessed by **bin**.
So, for generating the binary values from 1 to 8, with a step of 1, and a padding of 4 characters, the command
`bin 1 8 1 4`
will produce:
`0001
0010
0011
0100
0101
0110
0111
1000`